### PR TITLE
Fixed service provider namespace

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Instead, you may of course manually update your require block and run `composer 
 
 Once Laravel Desktop Notifier is installed, you need to register the service provider. Open up `config/app.php` and add the following to the `providers` key.
 
-* `'NunoMaduro\LaravelDesktopNotifierServiceProvider'`
+* `NunoMaduro\LaravelDesktopNotifier\LaravelDesktopNotifierServiceProvider::class`
 
 ## Usage with Trait
 


### PR DESCRIPTION
Hi namespace to service provider mentioned in readme is invalid
i got this below error after installing this package
```
 [Symfony\Component\Debug\Exception\FatalThrowableError]             
  Class 'NunoMaduro\LaravelDesktopNotifierServiceProvider' not found
```