### PR TITLE
ci: add PHP 8 testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.2.5|^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0",
-        "illuminate/console": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.20|^7.29|^8.12",
+        "illuminate/console": "^6.20|^7.29|^8.12",
         "jolicode/jolinotif": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Looks like the minimum dependency versions should be updated. I'll check which are required. 👍🏻