### PR TITLE
chore(deps): update to require Laravel 9 or later

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['8.1', '8.2']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Laravel Desktop Notifier was created by, and is maintained by [Nuno Maduro](http
 
 ## Installation
 
-> **Requires [PHP 7.2.5+](https://php.net/releases/)**
+> **Requires [PHP 8.1+](https://php.net/releases)**
 
 Require Laravel Desktop Notifier using [Composer](https://getcomposer.org):
 

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "keywords": ["laravel", "framework", "console", "artisan", "php", "wrapper", "JoliNotif", "notification", "notifier", "Nuno Maduro", "NunoMaduro"],
     "license": "MIT",
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/support": "^6.20|^7.29|^8.12|^9.0",
-        "illuminate/console": "^6.20|^7.29|^8.12|^9.0",
-        "jolicode/jolinotif": "^2.0"
+        "php": "^8.1",
+        "illuminate/support": "^9.0|^10.0",
+        "illuminate/console": "^9.0|^10.0",
+        "jolicode/jolinotif": "^2.5"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.7",
-        "phpunit/phpunit": "^8.5.23|^9.0"
+        "phpunit/phpunit": "^9.5"
     },
     "authors": [
         {


### PR DESCRIPTION
This updates to require Laravel 9 or later, and PHP 8.1 or later.